### PR TITLE
feature/add-fedora-40

### DIFF
--- a/tasks/install_requirements_redhat.yml
+++ b/tasks/install_requirements_redhat.yml
@@ -2,6 +2,20 @@
 - name: "Set variable required_packages to false."
   ansible.builtin.set_fact:
     required_packages: false
+- name: "Install terminal from hyper.is"
+  block:
+    - name: "Download Hyper Terminal package."
+      ansible.builtin.get_url:
+        url: "https://releases.hyper.is/download/rpm"
+        dest: "/tmp/hyper_amd64.rpm"
+        mode: "0o655"
+        owner: "{{ ansible_facts['user_uid'] }}"
+        group: "{{ ansible_facts['user_gid'] }}"
+
+    - name: "Install Hyper Terminal."
+      become: true
+      ansible.builtin.dnf:
+        deb: "/tmp/hyper_amd64.rpm" 
 
 - name: "Add repositories for required packages."
   become: true
@@ -59,7 +73,6 @@
     name: "{{ dnf_package.name }}"
     state: latest
   loop:
-    - { name: "hyper" }
     - { name: "firefox" }
     - { name: "vim" }
     - { name: "rustc" }

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-fedora_version: 39
+fedora_version: 40
 python_version: 3.12.2


### PR DESCRIPTION
- removed hyper as it's not a part of fedora 40 repos yet.
- added block for manual install of hyper.
- updated variable to 40 for fedora version.